### PR TITLE
Changed README to include more complete example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ dm4
 
 A simple pure Python file reader for Digital Micrograph's DM4 file format.
 
-This package would not have been possible without the documentation provided by Dr Chris Boothroyd at http://www.er-c.org/cbb/info/dmformat/ Thank you.
+This package would not have been possible without the documentation provided by Dr Chris Boothroyd at `<https://personal.ntu.edu.sg/cbb/info/dmformat/index.html>`_. Thank you!
 
 ############
 Installation

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Install the dm4 package along with dependencies for the example::
 
 Create a Python script, example_dm4.py, with the following content::
 
-.. code-block:: python
+.. code:: python
 
    import dm4
    import numpy as np

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 dm4
 ###
 
-A simple pure python file reader for Digital Micrograph's DM4 file format
+A simple pure Python file reader for Digital Micrograph's DM4 file format.
 
 This package would not have been possible without the documentation provided by Dr Chris Boothroyd at http://www.er-c.org/cbb/info/dmformat/ Thank you.
 

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,8 @@ Install the dm4 package along with dependencies for the example::
 
 Create a Python script, example_dm4.py, with the following content::
 
+.. code-block:: python
+
    import dm4
    import numpy as np
 

--- a/README.rst
+++ b/README.rst
@@ -17,27 +17,51 @@ Install using pip from the command line::
 #######
 Example
 #######
-   
-Below is a short example of reading the image data from a dm4 file.  A more complete example can be found in the tests.::
+
+Create a virtual environment::
+
+   python -m venv .venv
+
+Activate the virtual environment::
+
+   source .venv/bin/activate
+
+Install the dm4 package along with dependencies for the example::
+
+   pip install dm4[example]
+
+Create a Python script, example_dm4.py, with the following content::
 
    import dm4
+   import numpy as np
 
-   dm4data = dm4.DM4File.open("sample.dm4")
+   from PIL import Image
 
-   tags = dm4data.read_directory()
+   with dm4.DM4File.open("replace-me.dm4") as dm4data:
+      tags = dm4data.read_directory()
 
-   image_data_tag = tags.named_subdirs['ImageList'].unnamed_subdirs[1].named_subdirs['ImageData']
-   image_tag = image_data_tag.named_tags['Data']
-   
-   XDim = dm4data.read_tag_data(image_data_tag.named_subdirs['Dimensions'].unnamed_tags[0])
-   YDim = dm4data.read_tag_data(image_data_tag.named_subdirs['Dimensions'].unnamed_tags[1])
-   
-   np_array = np.array(dm4data.read_tag_data(image_tag), dtype=np.uint16)
-   np_array = np.reshape(np_array, (YDim, XDim))
-   
-   output_fullpath = "sample.tif"
-   image = PIL.Image.fromarray(np_array, 'I;16')
-   image.save(output_fullpath)        
+      image_data_tag = (
+         tags.named_subdirs["ImageList"].unnamed_subdirs[1].named_subdirs["ImageData"]
+      )
+      image_tag = image_data_tag.named_tags["Data"]
+
+      XDim = dm4data.read_tag_data(
+         image_data_tag.named_subdirs["Dimensions"].unnamed_tags[0]
+      )
+      YDim = dm4data.read_tag_data(
+         image_data_tag.named_subdirs["Dimensions"].unnamed_tags[1]
+      )
+
+      np_array = np.array(dm4data.read_tag_data(image_tag), dtype=np.uint16)
+      np_array = np.reshape(np_array, (YDim, XDim))
+
+      output_fullpath = "example.tif"
+      image = Image.fromarray(np_array, "I;16")
+      image.save(output_fullpath)
+
+Run the script::
+
+   python example_dm4.py
 
 ####
 Todo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dynamic = ["version", "description"]
 [project.optional-dependencies]
 test = [
     "numpy",
+    "Pillow"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dynamic = ["version", "description"]
 [project.optional-dependencies]
 test = [
     "numpy",
+]
+example = [
+    "numpy",
     "Pillow"
 ]
 


### PR DESCRIPTION
This fixes the broken link for the DM4 format specification information and adds a more complete example using a virtual environment. The `example` optional dependencies are added so to facilitate the new example.