### PR TITLE
Added more complete example to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ docs/_build/
 target/
 /.project
 /.pydevproject
+
+# Environments
+.envrc
+/.venv

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@
 dm4
 ###
 
-A simple pure python file reader for Digital Micrograph's DM4 file format
+A simple pure Python file reader for Digital Micrograph's DM4 file format.
 
-This package would not have been possible without the documentation provided by Dr Chris Boothroyd at http://www.er-c.org/cbb/info/dmformat/ Thank you.
+This package would not have been possible without the documentation provided by Dr Chris Boothroyd at `<https://personal.ntu.edu.sg/cbb/info/dmformat/index.html>`_. Thank you!
 
 ############
 Installation
@@ -17,27 +17,51 @@ Install using pip from the command line::
 #######
 Example
 #######
-   
-Below is a short example of reading the image data from a dm4 file.  A more complete example can be found in the tests.::
+
+Create a virtual environment::
+
+   python -m venv .venv
+
+Activate the virtual environment::
+
+   source .venv/bin/activate
+
+Install the dm4 package along with dependencies for the example::
+
+   pip install dm4[example]
+
+Create a Python script, example_dm4.py, with the following content::
 
    import dm4
+   import numpy as np
 
-   dm4data = dm4.DM4File.open("sample.dm4")
+   from PIL import Image
 
-   tags = dm4data.read_directory()
+   with dm4.DM4File.open("replace-me.dm4") as dm4data:
+      tags = dm4data.read_directory()
 
-   image_data_tag = tags.named_subdirs['ImageList'].unnamed_subdirs[1].named_subdirs['ImageData']
-   image_tag = image_data_tag.named_tags['Data']
-   
-   XDim = dm4data.read_tag_data(image_data_tag.named_subdirs['Dimensions'].unnamed_tags[0])
-   YDim = dm4data.read_tag_data(image_data_tag.named_subdirs['Dimensions'].unnamed_tags[1])
-   
-   np_array = np.array(dm4data.read_tag_data(image_tag), dtype=np.uint16)
-   np_array = np.reshape(np_array, (YDim, XDim))
-   
-   output_fullpath = "sample.tif"
-   image = PIL.Image.fromarray(np_array, 'I;16')
-   image.save(output_fullpath)        
+      image_data_tag = (
+         tags.named_subdirs["ImageList"].unnamed_subdirs[1].named_subdirs["ImageData"]
+      )
+      image_tag = image_data_tag.named_tags["Data"]
+
+      XDim = dm4data.read_tag_data(
+         image_data_tag.named_subdirs["Dimensions"].unnamed_tags[0]
+      )
+      YDim = dm4data.read_tag_data(
+         image_data_tag.named_subdirs["Dimensions"].unnamed_tags[1]
+      )
+
+      np_array = np.array(dm4data.read_tag_data(image_tag), dtype=np.uint16)
+      np_array = np.reshape(np_array, (YDim, XDim))
+
+      output_fullpath = "example.tif"
+      image = Image.fromarray(np_array, "I;16")
+      image.save(output_fullpath)
+
+Run the script::
+
+   python example_dm4.py
 
 ####
 Todo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dynamic = ["version", "description"]
 test = [
     "numpy",
 ]
+example = [
+    "numpy",
+    "Pillow"
+]
 
 [project.urls]
 Home = "https://github.com/nornir/dm4"


### PR DESCRIPTION
Hello again! The link to the DM4 documentation was broken. It led to a "Page Not Found" at the domain. I believe I have found the same page at a new URL.

This also prompted me to update the README with a more complete example using the PyPI package. 

This adds the `example` optional dependencies because the example uses dm4, numpy, and Pillow. It also updates the example code to use a context manager. I was getting the following error using the example code "as is" with Python v3.9 in a virtual environment:

```
Traceback (most recent call last):
  File "example_dm4.py", line 9, in <module>
    tags = dm4data.read_directory()
AttributeError: '_GeneratorContextManager' object has no attribute 'read_directory'
```

When I changed the example code to explicitly use the context manager and the `with` clause, the error was resolved.